### PR TITLE
Actualizar la estructura de respuesta en los controladores para inclu…

### DIFF
--- a/TryontechWebAPI/Clases/clsTallajeCliente.cs
+++ b/TryontechWebAPI/Clases/clsTallajeCliente.cs
@@ -44,16 +44,16 @@ namespace TryontechWebAPI.Clases
                 {
                     DBTryOnTech.TallajeClientes.Add(tallajeClienteEntidad); // Se agrega la talla del cliente
                     DBTryOnTech.SaveChanges();
-                    return new OkObjectResult(new { message = "Customer measurements successfully added." }); // Se utiliza OkObjectResult correctamente
+                    return new OkObjectResult(new { sucess = true, message = "Customer measurements successfully added." }); // Se utiliza OkObjectResult correctamente
                 }
                 else
                 {
-                    return new BadRequestObjectResult(new { message = "Incorrect measurements. Please double-check the values." }); // Se utiliza BadRequestObjectResult correctamente
+                    return new BadRequestObjectResult(new { sucess = false, message = "Incorrect measurements. Please double-check the values." }); // Se utiliza BadRequestObjectResult correctamente
                 }
             }
             catch (Exception ex)
             {
-                return new BadRequestObjectResult(new { message = "Couldn’t save size details: " + ex.Message }); // Se utiliza ObjectResult con código de estado
+                return new BadRequestObjectResult(new { sucess = false, message = "Couldn’t save size details: " + ex.Message }); // Se utiliza ObjectResult con código de estado
             }
         }
         public IActionResult Actualizar()
@@ -66,20 +66,20 @@ namespace TryontechWebAPI.Clases
                     TallajeCliente tallajeCli = Consultar(tallajeCliente.Id); // Se verifica que existe en la base de datos
                     if (tallajeCli == null)
                     {
-                        return new BadRequestObjectResult(new { message = "Measurements not found. Update failed." }); // Se corrige el uso de BadRequest
+                        return new BadRequestObjectResult(new { sucess = false,message = "Measurements not found. Update failed." }); // Se corrige el uso de BadRequest
                     }
                     DBTryOnTech.TallajeClientes.Update(tallajeClienteEntidad); // Se actualiza la talla del cliente
                     DBTryOnTech.SaveChanges();
-                    return new OkObjectResult(new { message = "Client measurements successfully updated" }); // Se utiliza OkObjectResult correctamente
+                    return new OkObjectResult(new { sucess = true, message = "Client measurements successfully updated" }); // Se utiliza OkObjectResult correctamente
                 }
                 else
                 {
-                    return new BadRequestObjectResult(new { message = "Incorrect measurements. Please double-check the values." }); // Se utiliza BadRequestObjectResult correctamente
+                    return new BadRequestObjectResult(new { sucess = false,message = "Incorrect measurements. Please double-check the values." }); // Se utiliza BadRequestObjectResult correctamente
                 }
             }
             catch (Exception ex)
             {
-                return new BadRequestObjectResult(new { message = "Update failed: " + ex.Message }); // Se utiliza ObjectResult con código de estado
+                return new BadRequestObjectResult(new { sucess = false,message = "Update failed: " + ex.Message }); // Se utiliza ObjectResult con código de estado
             }
         }
         public IActionResult Eliminar(int Id)
@@ -89,15 +89,15 @@ namespace TryontechWebAPI.Clases
                 TallajeCliente tallajeCli = Consultar(Id); // Se verifica que existe en la base de datos
                 if (tallajeCli == null)
                 {
-                    return new BadRequestObjectResult(new { message = "Measurements not found. Deletion failed." }); // Se corrige el uso de BadRequestObjectResult
+                    return new BadRequestObjectResult(new { sucess = false, message = "Measurements not found. Deletion failed." }); // Se corrige el uso de BadRequestObjectResult
                 }
                 DBTryOnTech.TallajeClientes.Remove(tallajeCli); // Se elimina la talla del cliente
                 DBTryOnTech.SaveChanges();
-                return new OkObjectResult(new { message = "Measurements successfully deleted" }); // Se utiliza OkObjectResult correctamente
+                return new OkObjectResult(new { sucess = true, message = "Measurements successfully deleted" }); // Se utiliza OkObjectResult correctamente
             }
             catch (Exception ex)
             {
-                return new BadRequestObjectResult(new { message = "Couldn't remove client measurements: " + ex.Message }); // Se utiliza ObjectResult con código de estado
+                return new BadRequestObjectResult(new { sucess = false,message = "Couldn't remove client measurements: " + ex.Message }); // Se utiliza ObjectResult con código de estado
             }
         }
         public TallajeCliente Consultar(int Id)

--- a/TryontechWebAPI/Controllers/Emailcontroller.cs
+++ b/TryontechWebAPI/Controllers/Emailcontroller.cs
@@ -22,14 +22,14 @@ namespace TryontechWebAPI.Controllers
         {
             if (string.IsNullOrWhiteSpace(model.Correo))
             {
-                return BadRequest(new { message = "El campo 'Correo' es obligatorio." });
+                return BadRequest(new { sucess = false, message = "El campo 'Correo' es obligatorio." });
             }
 
             int? usuarioId = await _emailService.SendEmail(model.Correo);
             if (usuarioId != null)
-                return Ok(new { message = "Código enviado con éxito", userId=usuarioId});
+                return Ok(new { sucess = true, message = "Código enviado con éxito", userId=usuarioId});
             else
-                return BadRequest(new { message = "Error al enviar código, verifica el email" });
+                return BadRequest(new { sucess = false, message = "Error al enviar código, verifica el email" });
         }
 
         public class EmailRequestModel

--- a/TryontechWebAPI/Controllers/LoginController.cs
+++ b/TryontechWebAPI/Controllers/LoginController.cs
@@ -29,7 +29,7 @@ namespace TryontechWebAPI.Controllers
             // Validar que los campos no estén vacíos
             if (string.IsNullOrEmpty(request.Correo) || string.IsNullOrEmpty(request.Password))
             {
-                return BadRequest(new { message = "Email and password are required." });
+                return BadRequest(new { sucess = true,message = "Email and password are required." });
             }
 
             // Validar las credenciales del usuario
@@ -37,10 +37,10 @@ namespace TryontechWebAPI.Controllers
             {
                 // Generar un token JWT
                 var token = GenerateJwtToken(usuario.Username, usuario.Rol);
-                return Ok(new { message = "Login successful!", Token = token });
+                return Ok(new { sucess = true,message = "Login successful!", Token = token });
             }
 
-            return Unauthorized(new { message = "Invalid Credentials" });
+            return Unauthorized(new { sucess = false, message = "Invalid Credentials" });
         }
 
         // Verificación del código de usuario
@@ -50,19 +50,19 @@ namespace TryontechWebAPI.Controllers
         {
             if (string.IsNullOrEmpty(request.Code))
             {
-                return BadRequest(new { message = "El código es obligatorio." });
+                return BadRequest(new { sucess = false, message = "El código es obligatorio." });
             }
 
             var usuario = _clsUsuario.ObtenerUsuarioPorId(request.UserId); // Usamos el `UserId` recibido del frontend
 
             if (usuario == null)
             {
-                return NotFound(new { message = "Usuario no encontrado." });
+                return NotFound(new { sucess = false, message = "Usuario no encontrado." });
             }
 
             if (usuario.Code != request.Code)
             {
-                return Unauthorized(new { message = "El código ingresado es incorrecto." });
+                return Unauthorized(new { sucess = false, message = "El código ingresado es incorrecto." });
             }
 
             // Código correcto: se invalida el código en la base de datos
@@ -72,7 +72,7 @@ namespace TryontechWebAPI.Controllers
             // Generar un token temporal solo para cambio de contraseña
             var token = GeneratePasswordResetToken(usuario.Id);
 
-            return Ok(new { message = "Código verificado exitosamente.", Token = token });
+            return Ok(new { sucess = true,message = "Código verificado exitosamente.", Token = token });
         }
 
         //Cambio de la contraseña y cifrado
@@ -82,14 +82,14 @@ namespace TryontechWebAPI.Controllers
         {
             if (string.IsNullOrEmpty(request.NewPassword))
             {
-                return BadRequest(new { message = "La nueva contraseña es obligatoria." });
+                return BadRequest(new { sucess = false, message = "La nueva contraseña es obligatoria." });
             }
 
             var usuario = _clsUsuario.ObtenerUsuarioPorId(request.UserId); // Usamos el `UserId` recibido del frontend
 
             if (usuario == null)
             {
-                return NotFound(new { message = "Usuario no encontrado." });
+                return NotFound(new { sucess = false, message = "Usuario no encontrado." });
             }
 
             var cypher = new clsCypher();
@@ -97,7 +97,7 @@ namespace TryontechWebAPI.Controllers
 
             if (!cypher.CifrarClave())
             {
-                return StatusCode(500, new { message = "Error al cifrar la nueva contraseña." });
+                return StatusCode(500, new { sucess = false, message = "Error al cifrar la nueva contraseña." });
             }
 
             usuario.Password = cypher.PasswordCifrado;
@@ -105,13 +105,13 @@ namespace TryontechWebAPI.Controllers
 
             _clsUsuario.ActualizarUsuario(usuario);
 
-            return Ok(new { message = "Contraseña actualizada exitosamente." });
+            return Ok(new { sucess = true, message = "Contraseña actualizada exitosamente." });
         }
 
         [HttpGet("protected")]
         public IActionResult ProtectedEndpoint()
         {
-            return Ok(new { message = "This is a protected endpoint", User = User.Identity.Name });
+            return Ok(new { sucess = true, message = "This is a protected endpoint", User = User.Identity.Name });
         }
 
         // Genera un token solo para cambio de contraseña

--- a/TryontechWebAPI/Controllers/ModeloController.cs
+++ b/TryontechWebAPI/Controllers/ModeloController.cs
@@ -28,7 +28,7 @@ namespace TryontechWebAPI.Controllers
             }
             catch (Exception ex)
             {
-                return BadRequest(new { message = "Ocurrió un error al asignar el modelo. Por favor, verifica los datos enviados e inténtalo nuevamente. Detalle: " + ex.Message });
+                return BadRequest(new { sucess = false, message = "Ocurrió un error al asignar el modelo. Por favor, verifica los datos enviados e inténtalo nuevamente. Detalle: " + ex.Message });
             }
         }
     }

--- a/TryontechWebAPI/Controllers/PhoneController.cs
+++ b/TryontechWebAPI/Controllers/PhoneController.cs
@@ -22,14 +22,14 @@ namespace TryontechWebAPI.Controllers
         public async Task<IActionResult> EnviarCodigo([FromBody] EnviarCodigoRequestDTO request)
         {
             if (request == null || string.IsNullOrEmpty(request.Telefono))
-                return BadRequest(new { message = "Datos inválidos." });
+                return BadRequest(new { sucess = false, message = "Datos inválidos." });
 
             int? usuarioId = await _phoneServices.EnviarCodigoPorTelefonoAsync(request.Telefono);
 
             if (usuarioId != null)
-                return Ok(new { message = "Código enviado correctamente.", userId = usuarioId });
+                return Ok(new { sucess=true,message = "Código enviado correctamente.", userId = usuarioId });
             else
-                return BadRequest(new { message = "Error al enviar el código." });
+                return BadRequest(new { sucess=false,message = "Error al enviar el código." });
         }
     }
 }

--- a/TryontechWebAPI/Controllers/ProfileController.cs
+++ b/TryontechWebAPI/Controllers/ProfileController.cs
@@ -46,11 +46,11 @@ namespace TryontechWebAPI.Controllers
                 // se modifico para que recibiera los parametros adecuados
                 string resultado = cliente.InsertarCliente(request.FechaNacimiento, request.Sexo, nuevoUsuario);
 
-                return Ok(new { message =resultado });
+                return Ok(new { sucess = true, message =resultado });
             }
             catch (Exception ex)
             {
-                return BadRequest(new { message = "Ocurrió un error al crear el usuario. Por favor, verifica los datos enviados e inténtalo nuevamente. Detalle: " + ex.Message });
+                return BadRequest(new { sucess = false,message = "Ocurrió un error al crear el usuario. Por favor, verifica los datos enviados e inténtalo nuevamente. Detalle: " + ex.Message });
             }
         }
         [HttpPost]


### PR DESCRIPTION
This pull request standardizes the response structure across multiple controllers and methods in the `TryontechWebAPI` project by introducing a `sucess` property in the returned JSON objects. This change improves consistency and makes it easier for the frontend to handle API responses uniformly.

### Standardization of Response Structure:

* Updated `Insertar`, `Actualizar`, and `Eliminar` methods in `clsTallajeCliente` to include a `sucess` property in both successful and error responses. [[1]](diffhunk://#diff-875c0d77471d4febcecdc732ddf1e0a2253be3d13efc96f51d82530272e26999L47-R56) [[2]](diffhunk://#diff-875c0d77471d4febcecdc732ddf1e0a2253be3d13efc96f51d82530272e26999L69-R82) [[3]](diffhunk://#diff-875c0d77471d4febcecdc732ddf1e0a2253be3d13efc96f51d82530272e26999L92-R100)
* Modified methods in `EmailController`, including `RequestCode`, to add `sucess` property to responses for email-related operations.
* Adjusted `LoginController` methods (`Login`, `VerifyCode`, `ChangePassword`, and `ProtectedEndpoint`) to include `sucess` property for authentication and user verification responses. [[1]](diffhunk://#diff-e4081eab8ab9ca239030031510caed62df0f83d1550d6cc0a034baeba79e4af9L32-R43) [[2]](diffhunk://#diff-e4081eab8ab9ca239030031510caed62df0f83d1550d6cc0a034baeba79e4af9L53-R65) [[3]](diffhunk://#diff-e4081eab8ab9ca239030031510caed62df0f83d1550d6cc0a034baeba79e4af9L75-R75) [[4]](diffhunk://#diff-e4081eab8ab9ca239030031510caed62df0f83d1550d6cc0a034baeba79e4af9L85-R114)
* Updated `ModeloController`'s `AsignarModelo` method to add the `sucess` property in error responses for model assignment operations.
* Enhanced `PhoneController`'s `EnviarCodigo` method to include `sucess` property in both successful and error responses for phone-related operations.
* Modified `ProfileController`'s `CrearCuenta` method to include the `sucess` property in responses for account creation.